### PR TITLE
Fix some memory leaks in NotyfyObject.close()

### DIFF
--- a/jquery.notyfy.js
+++ b/jquery.notyfy.js
@@ -185,6 +185,7 @@
 			close: function(event) {
 				if(self.closed) return;
 
+				$(window).unbind('resize.' + self.options.id);
 				// If we are still waiting in the queue just delete from queue
 				if(!self.shown) {
 					$.notyfy.queue = $.map($.notyfy.queue, function(n ,i) {
@@ -245,7 +246,8 @@
 			},
 
 			_removeContainerIfNew: function() {
-				self.container.filter('.i-am-new').remove()
+				self.container.filter('.i-am-new').remove();
+				delete self.container;
 			},
 
 			setText: function(text) {

--- a/jquery.notyfy.js
+++ b/jquery.notyfy.js
@@ -192,6 +192,8 @@
 							return n;
 						}
 					});
+					self._removeContainerIfNew();
+					delete $.notyfy.store[self.options.id];
 					return;
 				}
 
@@ -215,6 +217,7 @@
 					// Make sure self.wrapper has not been removed before attempting to remove it
 					if(typeof self.wrapper !== 'undefined' && self.wrapper !== null) {
 						self.wrapper.remove();
+						self._removeContainerIfNew()
 						self.wrapper = null;
 						self.closed = true;
 					}
@@ -239,6 +242,10 @@
 				// Otherwise just invoke show() and after()
 				else { self.wrapper.hide(); after(); }
 
+			},
+
+			_removeContainerIfNew: function() {
+				self.container.filter('.i-am-new').remove()
 			},
 
 			setText: function(text) {


### PR DESCRIPTION
I'm fixing some memory leaks in my application and some of them result from this plugin. Luckily this one was easy to fix. Now I'm going to investigate the causes for the jQRangeSlider plugin...

Without this patch it is easy to notice that some NotyfyObject's containers are still present under 'body' after close() is called. Only the li was being removed, not its ul container. There were also some other memory leaks which I believe should be all fixed now since the memory stopped growing up after creating and closing notifications...
